### PR TITLE
Update Dockerfile to use multistage builds

### DIFF
--- a/LoginService/Dockerfile
+++ b/LoginService/Dockerfile
@@ -12,21 +12,17 @@ COPY . .
 WORKDIR /app/LoginService
 RUN dotnet build
 
-FROM build AS testrunner
-WORKDIR /app/Tests
-ENTRYPOINT ["dotnet", "test", "--logger:trx"]
-
+# run tests
 FROM build AS test
 WORKDIR /app/Tests
 RUN dotnet test
 
+# generate final artifacts
 FROM build AS publish
 WORKDIR /app/LoginService
-RUN dotnet publish -c Release -o out
+RUN dotnet publish -c Release -o out /p:PublishWithAspNetCoreTargetManifest="false"
 
-# COPY ./LoginService ./
-# RUN dotnet publish -c Debug -o compiledOutput
-
+# create final image
 FROM microsoft/dotnet:2.0-runtime AS runtime
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://*:4201

--- a/LoginService/Dockerfile
+++ b/LoginService/Dockerfile
@@ -1,11 +1,35 @@
-FROM microsoft/dotnet:sdk AS build-env
+FROM microsoft/dotnet:2.0-sdk AS build
 WORKDIR /app
 
-COPY ./LoginService ./
-RUN dotnet publish -c Debug -o compiledOutput
+# copy csproj and restore as distinct layers
+COPY *.sln .
+COPY LoginService/*.csproj ./LoginService/
+COPY LoginServiceTests/*.csproj ./Tests/
+RUN dotnet restore
 
+# copy everything else and build app
+COPY . .
+WORKDIR /app/LoginService
+RUN dotnet build
+
+FROM build AS testrunner
+WORKDIR /app/Tests
+ENTRYPOINT ["dotnet", "test", "--logger:trx"]
+
+FROM build AS test
+WORKDIR /app/Tests
+RUN dotnet test
+
+FROM build AS publish
+WORKDIR /app/LoginService
+RUN dotnet publish -c Release -o out
+
+# COPY ./LoginService ./
+# RUN dotnet publish -c Debug -o compiledOutput
+
+FROM microsoft/dotnet:2.0-runtime AS runtime
+WORKDIR /app
 ENV ASPNETCORE_URLS=http://*:4201
 EXPOSE 4201
-
-WORKDIR compiledOutput
-ENTRYPOINT [ "dotnet", "LoginService.dll"]
+COPY --from=publish /app/LoginService/out ./
+ENTRYPOINT ["dotnet", "LoginService.dll"]


### PR DESCRIPTION
- Update dockerfile to use mutli stage builds for caching purposes
- Reduce the size of the docker image by only using the .net core runtime.