### PR TITLE
Removing keys that no longer exist in configmap

### DIFF
--- a/LoginService/charts/login-service/templates/login-service.configmap.yaml
+++ b/LoginService/charts/login-service/templates/login-service.configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.configmap.name }}
 data:
   AadAppId: "{{ .Values.configmap.aadAppId }}"
-  AadPasswordFilePath: '"./secrets/secrets/mt-aad-password"'
+  AadPasswordFilePath: '"/secrets/secrets/mt-aad-password"'
   ApplicationInsights.InstrumentationKey: "{{ .Values.configmap.appInsightsKey }}"
   CorsOrigins: "*"
   JwtAudience: "http://microsoft.com"

--- a/LoginService/charts/login-service/values.yaml
+++ b/LoginService/charts/login-service/values.yaml
@@ -58,12 +58,8 @@ hexadite:
 
 # Config map keys to set as environment variables in each container
 configs:
-  - name: TEST_VAL_KEY
-    key: testdata
   - name: APP_INSIGHTS_KEY
     key: ApplicationInsights.InstrumentationKey
-  - name: JWT_KEY
-    key: JwtKey
   - name: JWT_ISSUER
     key: JwtIssuer
   - name: JWT_AUDIENCE


### PR DESCRIPTION
Removing keys that no longer exist in configmap. Pods will fail to startup if these keys don't exist.